### PR TITLE
Add "forceDeleting" model event

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -98,7 +98,7 @@ trait HasEvents
             [
                 'retrieved', 'creating', 'created', 'updating', 'updated',
                 'saving', 'saved', 'restoring', 'restored', 'replicating',
-                'deleting', 'deleted', 'forceDeleted',
+                'deleting', 'deleted', 'forceDeleting', 'forceDeleted',
             ],
             $this->observables
         );

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -45,6 +45,10 @@ trait SoftDeletes
      */
     public function forceDelete()
     {
+        if ($this->fireModelEvent('forceDeleting') === false) {
+            return false;
+        }
+
         $this->forceDeleting = true;
 
         return tap($this->delete(), function ($deleted) {
@@ -189,6 +193,17 @@ trait SoftDeletes
     public static function restored($callback)
     {
         static::registerModelEvent('restored', $callback);
+    }
+
+    /**
+     * Register a "forceDeleting" model event callback with the dispatcher.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public static function forceDeleting($callback)
+    {
+        static::registerModelEvent('forceDeleting', $callback);
     }
 
     /**

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -56,6 +56,17 @@ class EloquentDeleteTest extends DatabaseTestCase
         $this->assertCount(8, Post::all());
     }
 
+    public function testForceDeletingEventIsFired()
+    {
+        $role = Role::create([]);
+        $this->assertInstanceOf(Role::class, $role);
+        Role::observe(new RoleObserver());
+
+        $role->forceDelete();
+
+        $this->assertEquals($role->id, RoleObserver::$model->id);
+    }
+
     public function testForceDeletedEventIsFired()
     {
         $role = Role::create([]);


### PR DESCRIPTION
Before
``` php
    public static function booted()
    {
        static::deleting(function (User $user) {
            if ($user->isForceDeleting()) {
                //
            }
        });
    }
```
After
``` php
    public static function booted()
    {
        static::forceDeleting(function (User $user) {
            // do something
        });
    }
```